### PR TITLE
append request path to the login url

### DIFF
--- a/lib/rack/cas_client.rb
+++ b/lib/rack/cas_client.rb
@@ -395,7 +395,9 @@ module Rack
           validation_retry = 0
         end
         previous_redirect_to_cas = Time.now
-        
+
+        redirect_url += '&from=' + URI.encode_www_form_component(env['ORIGINAL_FULLPATH'])
+
         request  = Rack::Request.new(env)
         response = Rack::Response.new(["redirect to #{redirect_url}"],302, {'Location' => redirect_url, 'Content-Type' => 'text/plain'})
 


### PR DESCRIPTION
This in combination with https://github.com/rubycas/rubycas-server/pull/231 makes it possible to cleanly redirect the user to the page he came after login from without invalidating his service ticket.

Needs to be a GET parameter because browsers do not necessarily send Referer header when hitting a 302